### PR TITLE
Add ISBN argument to the object creation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,6 @@ create abc("978-1-51916-691-3", "The Alphabet") as Book {
 This is how we create another object, copying an existing one:
 
 ```
-copy abc("Object Thinking")
+copy abc("978-0-73561-965-4", "Object Thinking")
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ type Book {
 This is how we create a new object:
 
 ```
-create abc("The Alphabet") as Book {
+create abc("978-1-51916-691-3", "The Alphabet") as Book {
   String isbn;
   String title;
   Book(ISBN i, String t):


### PR DESCRIPTION
In the example for creating an object only a title is supplied. And yet the constructor needs an ISBN also.