### PR TITLE
Clarify MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+ The MIT License (MIT)
+ 
+ Copyright (c) 2016 eolang.org
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -358,5 +358,6 @@ Here, `if`, `firstIsLess`, `plus`, and `minus` are objects being copied.
 
 * Copyright (c) 2016 eolang.org [contributors](https://github.com/yegor256/eo/graphs/contributors)
 
-The EO documentation and [eo-compiler](eo-compiler) is distributed under 
-**The MIT License**. See [LICENSE](LICENSE) for details.
+This EO documentation, examples and the [eo-compiler](eo-compiler) 
+is distributed under [The MIT License](http://www.opensource.org/licenses/MIT). 
+See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -353,3 +353,10 @@ object fibonacci(1) as Int:
 ```
 
 Here, `if`, `firstIsLess`, `plus`, and `minus` are objects being copied.
+
+# License
+
+* Copyright (c) 2016 eolang.org [contributors](https://github.com/yegor256/eo/graphs/contributors)
+
+The EO documentation and [eo-compiler](eo-compiler) is distributed under 
+**The MIT License**. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
This augments #64 so that it is clear from the front page that the specification as well as the reference implementation is distributed under the MIT license.

(Note: there is already `LICENSE.txt` under `eo-compiler/` and `eo-maven-plugin`)