### PR TITLE
TypeTest checks whole Java code

### DIFF
--- a/eo-compiler/src/test/java/org/eolang/compiler/syntax/TypeTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/syntax/TypeTest.java
@@ -56,7 +56,13 @@ public final class TypeTest {
                     )
                 )
             ).java().getValue(),
-            Matchers.containsString("final Integer x")
+            Matchers.stringContainsInOrder(
+                Lists.newArrayList(
+                    "public interface Car", "{",
+                        "Int drive(final Integer x, final Long y);",
+                    "}"
+                )
+            )
         );
     }
 


### PR DESCRIPTION
The test named `generatesJavaFile` from `TypeTest` wasn't checking if full code for the type was correctly generated. Now it does.