### PR TITLE
Adding a quick test for the compiler's Argument class.

### DIFF
--- a/eo-compiler/src/test/java/org/eolang/compiler/syntax/ArgumentTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/syntax/ArgumentTest.java
@@ -27,8 +27,14 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+/**
+ * Hmm...
+ */
 public final class ArgumentTest {
 
+    /**
+     * Not sure I like these comments being enforced.
+     */
     @Test
     public void generatesJavaCode() throws Exception {
         MatcherAssert.assertThat(
@@ -41,5 +47,4 @@ public final class ArgumentTest {
                 )
         );
     }
-
 }

--- a/eo-compiler/src/test/java/org/eolang/compiler/syntax/ArgumentTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/syntax/ArgumentTest.java
@@ -1,25 +1,25 @@
-/*
-  The MIT License (MIT)
-
-  Copyright (c) 2016 eolang.org
-
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included
-  in all copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  SOFTWARE.
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 eolang.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 package org.eolang.compiler.syntax;
 
@@ -28,23 +28,27 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Hmm...
+ * Test class for {@link Argument}.
+ * @author John Page (johnpagedev@gmail.com)
+ * @version $Id$
+ * @since 0.1
  */
 public final class ArgumentTest {
 
     /**
-     * Not sure I like these comments being enforced.
+     * A test that checks that Argument generates Java code.
+     * @throws Exception if, well, an exception occurs.
      */
     @Test
     public void generatesJavaCode() throws Exception {
         MatcherAssert.assertThat(
-                new Argument(
-                        "dollars",
-                        "Cash"
-                ).java(),
-                Matchers.is(
-                        "final Cash dollars"
-                )
+            new Argument(
+                "dollars",
+                "Cash"
+            ).java(),
+            Matchers.is(
+                "final Cash dollars"
+            )
         );
     }
 }

--- a/eo-compiler/src/test/java/org/eolang/compiler/syntax/ArgumentTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/syntax/ArgumentTest.java
@@ -1,0 +1,45 @@
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2016 eolang.org
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+ */
+package org.eolang.compiler.syntax;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+public final class ArgumentTest {
+
+    @Test
+    public void generatesJavaCode() throws Exception {
+        MatcherAssert.assertThat(
+                new Argument(
+                        "dollars",
+                        "Cash"
+                ).java(),
+                Matchers.is(
+                        "final Cash dollars"
+                )
+        );
+    }
+
+}


### PR DESCRIPTION
Adding a test to show that the Argument class generates Java code.

Just a simple change as I'm just getting used to IntelliJ. :)

~~Didn't use a Javadoc-style comment for the license commnet as IntelliJ said that it was "dangling", i.e. not associated with any class, method or field.~~