### PR TITLE
#95 - Implemented EO object to java class generator

### DIFF
--- a/eo-compiler/src/main/antlr4/org/eolang/compiler/Program.g4
+++ b/eo-compiler/src/main/antlr4/org/eolang/compiler/Program.g4
@@ -5,6 +5,7 @@ grammar Program;
     import org.eolang.compiler.syntax.Method;
     import org.eolang.compiler.syntax.Tree;
     import org.eolang.compiler.syntax.Type;
+    import org.eolang.compiler.syntax.RootNode;
     import java.util.Collection;
     import java.util.LinkedList;
 }
@@ -107,17 +108,17 @@ tokens { INDENT, DEDENT }
 
 program returns [Tree ret]
     :
-    { Collection<Type> types = new LinkedList<Type>(); }
+    { Collection<RootNode> nodes = new LinkedList<RootNode>(); }
     (
         type_declaration
-        { types.add($type_declaration.ret); }
+        { nodes.add($type_declaration.ret); }
         |
         object_instantiation
         |
         object_copying
     )*
     EOF
-    { $ret = new Tree(types); }
+    { $ret = new Tree(nodes); }
     ;
 
 type_declaration returns [Type ret]

--- a/eo-compiler/src/main/antlr4/org/eolang/compiler/Program.g4
+++ b/eo-compiler/src/main/antlr4/org/eolang/compiler/Program.g4
@@ -5,6 +5,7 @@ grammar Program;
     import org.eolang.compiler.syntax.Method;
     import org.eolang.compiler.syntax.Tree;
     import org.eolang.compiler.syntax.Type;
+    import org.eolang.compiler.syntax.Object;
     import org.eolang.compiler.syntax.RootNode;
     import java.util.Collection;
     import java.util.LinkedList;
@@ -114,6 +115,7 @@ program returns [Tree ret]
         { nodes.add($type_declaration.ret); }
         |
         object_instantiation
+        { nodes.add($object_instantiation.ret); }
         |
         object_copying
     )*
@@ -184,20 +186,34 @@ argument_declaration returns [Argument ret]
     { $ret = new Argument($LONAME.text, $HINAME.text); }
     ;
 
-object_instantiation
+object_types_declaration returns [Collection<String> ret]
     :
-    OBJECT
-    SPACE
-    LONAME
-    SPACE
-    AS
+    { $ret = new LinkedList<String>(); }
     SPACE
     HINAME
+    { $ret.add($HINAME.text); }
     (
         COMMA
         SPACE
         HINAME
+        { $ret.add($HINAME.text); }
     )*
+    ;
+
+object_name returns [String ret]
+    :
+    LONAME
+    { $ret = $LONAME.text; }
+    ;
+
+object_instantiation returns [Object ret]
+    :
+    OBJECT
+    SPACE
+    object_name
+    SPACE
+    AS
+    object_types_declaration
     COLON
     NEWLINE
     INDENT
@@ -214,6 +230,7 @@ object_instantiation
         NEWLINE
     )*
     DEDENT
+    { $ret = new Object($object_name.ret, $object_types_declaration.ret); }
     ;
 
 attribute_declaration
@@ -227,15 +244,17 @@ ctor_declaration
     :
     CTOR
     arguments_declaration
-    COLON
-    NEWLINE
-    INDENT
     (
-        object_instantiation
-        |
-        object_copying
-    )
-    DEDENT
+        COLON
+        NEWLINE
+        INDENT
+        (
+            object_instantiation
+            |
+            object_copying
+        )
+        DEDENT
+    )?
     ;
 
 method_implementation

--- a/eo-compiler/src/main/java/org/eolang/compiler/java/JavaClass.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/java/JavaClass.java
@@ -25,6 +25,8 @@ package org.eolang.compiler.java;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * File with java class.
@@ -32,6 +34,15 @@ import java.nio.file.Paths;
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
+ *
+ * @todo #95:30m Java class constructor generator is not implemented.
+ *  We may pass object constructor params as `JavaClass` constructor arguments.
+ *  Also we need to implement object instance as `public static final` variable
+ *  in generated java class, as described in #95.
+ *
+ * @todo #95:30m Java class method generator is not implemented.
+ *  We may pass collection of methods as `JavaClass` constructor arguments.
+ *  All methods should be public.
  */
 public final class JavaClass implements JavaFile {
 
@@ -43,7 +54,7 @@ public final class JavaClass implements JavaFile {
     /**
      * Implemented interface name.
      */
-    private final String iface;
+    private final Collection<String> ifaces;
 
     /**
      * Ctor.
@@ -52,8 +63,18 @@ public final class JavaClass implements JavaFile {
      * @param iface Implemented interface name
      */
     public JavaClass(final String name, final String iface) {
+        this(name, Collections.singleton(iface));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param name Class name
+     * @param ifaces Implemented interfaces name
+     */
+    public JavaClass(final String name, final Collection<String> ifaces) {
         this.name = name;
-        this.iface = iface;
+        this.ifaces = ifaces;
     }
 
     @Override
@@ -66,7 +87,7 @@ public final class JavaClass implements JavaFile {
         return String.format(
             "public final class %s implements %s {\n %s\n}",
             this.name,
-            this.iface,
+            String.join(", ", this.ifaces),
             "public static final "
         );
     }

--- a/eo-compiler/src/main/java/org/eolang/compiler/java/JavaClass.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/java/JavaClass.java
@@ -21,48 +21,53 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.compiler.syntax;
+package org.eolang.compiler.java;
 
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.eolang.compiler.java.JavaFile;
+import java.nio.file.Paths;
 
 /**
- * AST.
+ * File with java class.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
+ * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class Tree {
+public final class JavaClass implements JavaFile {
 
     /**
-     * Root nodes.
+     * Class name.
      */
-    private final Collection<RootNode> nodes;
+    private final String name;
+
+    /**
+     * Implemented interface name.
+     */
+    private final String iface;
 
     /**
      * Ctor.
-     * @param nodes All AST root nodes.
+     *
+     * @param name Class name
+     * @param iface Implemented interface name
      */
-    public Tree(final Collection<RootNode> nodes) {
-        this.nodes = nodes;
+    public JavaClass(final String name, final String iface) {
+        this.name = name;
+        this.iface = iface;
     }
 
-    /**
-     * Compile it to Java files.
-     * @return Java files (path, content)
-     */
-    public Map<Path, String> java() {
-        return this.nodes.stream()
-            .map(RootNode::java)
-            .collect(
-                Collectors.toMap(
-                    JavaFile::path,
-                    JavaFile::code
-                )
-            );
+    @Override
+    public Path path() {
+        return Paths.get(String.format("%s.java", this.name));
+    }
+
+    @Override
+    public String code() {
+        return String.format(
+            "public final class %s implements %s {\n %s\n}",
+            this.name,
+            this.iface,
+            "public static final "
+        );
     }
 }

--- a/eo-compiler/src/main/java/org/eolang/compiler/java/JavaFile.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/java/JavaFile.java
@@ -21,48 +21,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.compiler.syntax;
+package org.eolang.compiler.java;
 
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.eolang.compiler.java.JavaFile;
 
 /**
- * AST.
+ * Java file representation.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
+ * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class Tree {
+public interface JavaFile {
 
     /**
-     * Root nodes.
+     * Java file path.
+     *
+     * @return File path
      */
-    private final Collection<RootNode> nodes;
+    Path path();
 
     /**
-     * Ctor.
-     * @param nodes All AST root nodes.
+     * Java file content.
+     *
+     * @return Java code
      */
-    public Tree(final Collection<RootNode> nodes) {
-        this.nodes = nodes;
-    }
-
-    /**
-     * Compile it to Java files.
-     * @return Java files (path, content)
-     */
-    public Map<Path, String> java() {
-        return this.nodes.stream()
-            .map(RootNode::java)
-            .collect(
-                Collectors.toMap(
-                    JavaFile::path,
-                    JavaFile::code
-                )
-            );
-    }
+    String code();
 }

--- a/eo-compiler/src/main/java/org/eolang/compiler/java/JavaInterface.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/java/JavaInterface.java
@@ -21,48 +21,59 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.compiler.syntax;
+package org.eolang.compiler.java;
 
+import com.google.common.base.Joiner;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
-import java.util.Map;
 import java.util.stream.Collectors;
-import org.eolang.compiler.java.JavaFile;
+import org.eolang.compiler.syntax.Method;
 
 /**
- * AST.
+ * File with java interface.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
+ * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class Tree {
+public final class JavaInterface implements JavaFile {
+    /**
+     * Interface name.
+     */
+    private final String name;
 
     /**
-     * Root nodes.
+     * Methods.
      */
-    private final Collection<RootNode> nodes;
+    private final Collection<Method> methods;
 
     /**
      * Ctor.
-     * @param nodes All AST root nodes.
+     *
+     * @param name Interface name
+     * @param methods Interface methods
      */
-    public Tree(final Collection<RootNode> nodes) {
-        this.nodes = nodes;
+    public JavaInterface(final String name, final Collection<Method> methods) {
+        this.name = name;
+        this.methods = methods;
     }
 
-    /**
-     * Compile it to Java files.
-     * @return Java files (path, content)
-     */
-    public Map<Path, String> java() {
-        return this.nodes.stream()
-            .map(RootNode::java)
-            .collect(
-                Collectors.toMap(
-                    JavaFile::path,
-                    JavaFile::code
-                )
-            );
+    @Override
+    public Path path() {
+        return Paths.get(String.format("%s.java", this.name));
+    }
+
+    @Override
+    public String code() {
+        return String.format(
+            "public interface %s {\n    %s\n}",
+            this.name,
+            Joiner.on("\n    ").join(
+                this.methods.stream().map(
+                    Method::java
+                ).collect(Collectors.toList())
+            )
+        );
     }
 }

--- a/eo-compiler/src/main/java/org/eolang/compiler/java/package-info.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/java/package-info.java
@@ -21,48 +21,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.compiler.syntax;
-
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.eolang.compiler.java.JavaFile;
-
-/**
- * AST.
- *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
- * @since 0.1
- */
-public final class Tree {
-
-    /**
-     * Root nodes.
-     */
-    private final Collection<RootNode> nodes;
-
-    /**
-     * Ctor.
-     * @param nodes All AST root nodes.
-     */
-    public Tree(final Collection<RootNode> nodes) {
-        this.nodes = nodes;
-    }
-
-    /**
-     * Compile it to Java files.
-     * @return Java files (path, content)
-     */
-    public Map<Path, String> java() {
-        return this.nodes.stream()
-            .map(RootNode::java)
-            .collect(
-                Collectors.toMap(
-                    JavaFile::path,
-                    JavaFile::code
-                )
-            );
-    }
-}
+package org.eolang.compiler.java;

--- a/eo-compiler/src/main/java/org/eolang/compiler/syntax/Object.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/syntax/Object.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.compiler.syntax;
 
+import java.util.Collection;
 import org.eolang.compiler.java.JavaClass;
 import org.eolang.compiler.java.JavaFile;
 
@@ -45,23 +46,23 @@ public final class Object implements RootNode {
     private final String name;
 
     /**
-     * Object type.
+     * Object types.
      */
-    private final String type;
+    private final Collection<String> types;
 
     /**
      * Ctor.
      *
      * @param name Object name
-     * @param type Object type
+     * @param types Object types
      */
-    public Object(final String name, final String type) {
+    public Object(final String name, final Collection<String> types) {
         this.name = name;
-        this.type = type;
+        this.types = types;
     }
 
     @Override
     public JavaFile java() {
-        return new JavaClass(this.name, this.type);
+        return new JavaClass(this.name, this.types);
     }
 }

--- a/eo-compiler/src/main/java/org/eolang/compiler/syntax/Object.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/syntax/Object.java
@@ -23,46 +23,45 @@
  */
 package org.eolang.compiler.syntax;
 
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Map;
-import java.util.stream.Collectors;
+import org.eolang.compiler.java.JavaClass;
 import org.eolang.compiler.java.JavaFile;
 
 /**
- * AST.
+ * EO Object.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
+ * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class Tree {
+public final class Object implements RootNode {
 
     /**
-     * Root nodes.
+     * Object name.
+     *
+     * @todo #95:30m Object name should be optional.
+     *  As described in #54, object can be anonymous.
+     *  I think we should generate some java class name in this case.
      */
-    private final Collection<RootNode> nodes;
+    private final String name;
+
+    /**
+     * Object type.
+     */
+    private final String type;
 
     /**
      * Ctor.
-     * @param nodes All AST root nodes.
+     *
+     * @param name Object name
+     * @param type Object type
      */
-    public Tree(final Collection<RootNode> nodes) {
-        this.nodes = nodes;
+    public Object(final String name, final String type) {
+        this.name = name;
+        this.type = type;
     }
 
-    /**
-     * Compile it to Java files.
-     * @return Java files (path, content)
-     */
-    public Map<Path, String> java() {
-        return this.nodes.stream()
-            .map(RootNode::java)
-            .collect(
-                Collectors.toMap(
-                    JavaFile::path,
-                    JavaFile::code
-                )
-            );
+    @Override
+    public JavaFile java() {
+        return new JavaClass(this.name, this.type);
     }
 }

--- a/eo-compiler/src/main/java/org/eolang/compiler/syntax/RootNode.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/syntax/RootNode.java
@@ -23,46 +23,21 @@
  */
 package org.eolang.compiler.syntax;
 
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Map;
-import java.util.stream.Collectors;
 import org.eolang.compiler.java.JavaFile;
 
 /**
- * AST.
+ * AST root node. A part of {@link Tree}.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
+ * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class Tree {
+public interface RootNode {
 
     /**
-     * Root nodes.
+     * Convert it to java code.
+     *
+     * @return Java code and path
      */
-    private final Collection<RootNode> nodes;
-
-    /**
-     * Ctor.
-     * @param nodes All AST root nodes.
-     */
-    public Tree(final Collection<RootNode> nodes) {
-        this.nodes = nodes;
-    }
-
-    /**
-     * Compile it to Java files.
-     * @return Java files (path, content)
-     */
-    public Map<Path, String> java() {
-        return this.nodes.stream()
-            .map(RootNode::java)
-            .collect(
-                Collectors.toMap(
-                    JavaFile::path,
-                    JavaFile::code
-                )
-            );
-    }
+    JavaFile java();
 }

--- a/eo-compiler/src/main/java/org/eolang/compiler/syntax/Type.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/syntax/Type.java
@@ -23,13 +23,9 @@
  */
 package org.eolang.compiler.syntax;
 
-import com.google.common.base.Joiner;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.AbstractMap;
 import java.util.Collection;
-import java.util.Map;
-import java.util.stream.Collectors;
+import org.eolang.compiler.java.JavaFile;
+import org.eolang.compiler.java.JavaInterface;
 
 /**
  * Type.
@@ -38,10 +34,10 @@ import java.util.stream.Collectors;
  * @version $Id$
  * @since 0.1
  */
-public final class Type {
+public final class Type implements RootNode {
 
     /**
-     * Text to parse.
+     * Type name.
      */
     private final String name;
 
@@ -52,6 +48,7 @@ public final class Type {
 
     /**
      * Ctor.
+     *
      * @param label Type name
      * @param mts Methods
      */
@@ -60,23 +57,8 @@ public final class Type {
         this.methods = mts;
     }
 
-    /**
-     * Convert it to Java file (path, content).
-     * @return Java code
-     */
-    public Map.Entry<Path, String> java() {
-        return new AbstractMap.SimpleEntry<>(
-            Paths.get(String.format("%s.java", this.name)),
-            String.format(
-                "public interface %s {\n    %s\n}",
-                this.name,
-                Joiner.on("\n    ").join(
-                    this.methods.stream().map(
-                        Method::java
-                    ).collect(Collectors.toList())
-                )
-            )
-        );
+    @Override
+    public JavaFile java() {
+        return new JavaInterface(this.name, this.methods);
     }
-
 }

--- a/eo-compiler/src/test/java/org/eolang/compiler/ProgramTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/ProgramTest.java
@@ -27,10 +27,10 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -40,20 +40,77 @@ import org.junit.Test;
  * @version $Id$
  * @since 0.1
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class ProgramTest {
+
+    /**
+     * Test zero example, this object implements two interfaces.
+     *
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void processZeroExample() throws Exception {
+        final Program program = new Program(
+            IOUtils.toString(
+                this.getClass().getResourceAsStream("zero.eo"),
+                Charset.defaultCharset()
+            )
+        );
+        final Path dir = Files.createTempDirectory("");
+        program.save(dir);
+        MatcherAssert.assertThat(
+            new String(
+                Files.readAllBytes(dir.resolve(Paths.get("zero.java")))
+            ),
+            Matchers.stringContainsInOrder(
+                Arrays.asList(
+                    "public",
+                    "final",
+                    "class",
+                    "zero",
+                    "implements",
+                    "Money",
+                    ",",
+                    "Int",
+                    "{",
+                    "}"
+                )
+            )
+        );
+    }
 
     /**
      * Program can parse a simple fibonacci example.
      *
-     * @todo #70:30m Object parser is missing.
-     *  We need to implement it, but before we should decide
-     *  how to generate java code from EO object.
      * @throws Exception If some problem inside
      */
     @Test
-    @Ignore("object parsing is not implemented yet")
     public void parsesFibonacciExample() throws Exception {
-        //object parsing is not implemented yet
+        final Program program = new Program(
+            IOUtils.toString(
+                this.getClass().getResourceAsStream("fibonacci.eo"),
+                Charset.defaultCharset()
+            )
+        );
+        final Path dir = Files.createTempDirectory("");
+        program.save(dir);
+        MatcherAssert.assertThat(
+            new String(
+                Files.readAllBytes(dir.resolve(Paths.get("fibonacci.java")))
+            ),
+            Matchers.stringContainsInOrder(
+                Arrays.asList(
+                    "public",
+                    "final",
+                    "class",
+                    "fibonacci",
+                    "implements",
+                    "Int",
+                    "{",
+                    "}"
+                )
+            )
+        );
     }
 
     /**

--- a/eo-compiler/src/test/java/org/eolang/compiler/java/JavaClassTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/java/JavaClassTest.java
@@ -21,48 +21,66 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.compiler.syntax;
+package org.eolang.compiler.java;
 
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.eolang.compiler.java.JavaFile;
+import java.util.Arrays;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
 
 /**
- * AST.
+ * Java class generator test.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
+ * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class Tree {
+public final class JavaClassTest {
 
     /**
-     * Root nodes.
+     * Test class code.
      */
-    private final Collection<RootNode> nodes;
-
-    /**
-     * Ctor.
-     * @param nodes All AST root nodes.
-     */
-    public Tree(final Collection<RootNode> nodes) {
-        this.nodes = nodes;
+    @Test
+    public void classCode() {
+        final String name = "Cat";
+        final String type = "Animal";
+        MatcherAssert.assertThat(
+            new JavaClass(
+                name,
+                type
+            ).code(),
+            Matchers.stringContainsInOrder(
+                Arrays.asList(
+                    "public",
+                    "final",
+                    "class",
+                    name,
+                    "implements",
+                    type,
+                    "{",
+                    "}"
+                )
+            )
+        );
     }
 
     /**
-     * Compile it to Java files.
-     * @return Java files (path, content)
+     * Test class path.
      */
-    public Map<Path, String> java() {
-        return this.nodes.stream()
-            .map(RootNode::java)
-            .collect(
-                Collectors.toMap(
-                    JavaFile::path,
-                    JavaFile::code
+    @Test
+    public void classPath() {
+        final String name = "Book";
+        MatcherAssert.assertThat(
+            new JavaClass(
+                name,
+                "Text"
+            ).path().toString(),
+            Matchers.equalTo(
+                String.format(
+                    "%s.java",
+                    name
                 )
-            );
+            )
+        );
     }
 }

--- a/eo-compiler/src/test/java/org/eolang/compiler/java/JavaClassTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/java/JavaClassTest.java
@@ -24,6 +24,7 @@
 package org.eolang.compiler.java;
 
 import java.util.Arrays;
+import java.util.Collection;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -35,6 +36,7 @@ import org.junit.Test;
  * @version $Id$
  * @since 0.1
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class JavaClassTest {
 
     /**
@@ -59,6 +61,33 @@ public final class JavaClassTest {
                     type,
                     "{",
                     "}"
+                )
+            )
+        );
+    }
+
+    /**
+     * Test class with multiple interfaces.
+     */
+    @Test
+    public void multiTypes() {
+        final String name = "pdf";
+        final Collection<String> types = Arrays.asList("Text", "Book");
+        MatcherAssert.assertThat(
+            new JavaClass(
+                name,
+                types
+            ).code(),
+            Matchers.stringContainsInOrder(
+                Arrays.asList(
+                    "public",
+                    "final",
+                    "class",
+                    name,
+                    "implements",
+                    "Text", ",",
+                    "Book",
+                    "{", "}"
                 )
             )
         );

--- a/eo-compiler/src/test/java/org/eolang/compiler/java/JavaInterfaceTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/java/JavaInterfaceTest.java
@@ -21,48 +21,63 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.compiler.syntax;
+package org.eolang.compiler.java;
 
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.eolang.compiler.java.JavaFile;
+import java.util.Arrays;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
 
 /**
- * AST.
+ * Java interface generator test.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
+ * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class Tree {
+public final class JavaInterfaceTest {
 
     /**
-     * Root nodes.
+     * Test interface code.
      */
-    private final Collection<RootNode> nodes;
-
-    /**
-     * Ctor.
-     * @param nodes All AST root nodes.
-     */
-    public Tree(final Collection<RootNode> nodes) {
-        this.nodes = nodes;
+    @Test
+    public void interfaceCode() {
+        final String name = "Cat";
+        MatcherAssert.assertThat(
+            new JavaInterface(
+                name,
+                Collections.emptyList()
+            ).code(),
+            Matchers.stringContainsInOrder(
+                Arrays.asList(
+                    "public",
+                    "interface",
+                    name,
+                    "{",
+                    "}"
+                )
+            )
+        );
     }
 
     /**
-     * Compile it to Java files.
-     * @return Java files (path, content)
+     * Test interface path.
      */
-    public Map<Path, String> java() {
-        return this.nodes.stream()
-            .map(RootNode::java)
-            .collect(
-                Collectors.toMap(
-                    JavaFile::path,
-                    JavaFile::code
+    @Test
+    public void interfacePath() {
+        final String name = "Book";
+        MatcherAssert.assertThat(
+            new JavaInterface(
+                name,
+                Collections.emptyList()
+            ).path().toString(),
+            Matchers.equalTo(
+                String.format(
+                    "%s.java",
+                    name
                 )
-            );
+            )
+        );
     }
 }

--- a/eo-compiler/src/test/java/org/eolang/compiler/java/package-info.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/java/package-info.java
@@ -21,48 +21,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.compiler.syntax;
-
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.eolang.compiler.java.JavaFile;
 
 /**
- * AST.
+ * Syntax AST classes, tests.
  *
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class Tree {
-
-    /**
-     * Root nodes.
-     */
-    private final Collection<RootNode> nodes;
-
-    /**
-     * Ctor.
-     * @param nodes All AST root nodes.
-     */
-    public Tree(final Collection<RootNode> nodes) {
-        this.nodes = nodes;
-    }
-
-    /**
-     * Compile it to Java files.
-     * @return Java files (path, content)
-     */
-    public Map<Path, String> java() {
-        return this.nodes.stream()
-            .map(RootNode::java)
-            .collect(
-                Collectors.toMap(
-                    JavaFile::path,
-                    JavaFile::code
-                )
-            );
-    }
-}
+package org.eolang.compiler.java;

--- a/eo-compiler/src/test/java/org/eolang/compiler/syntax/TypeTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/syntax/TypeTest.java
@@ -55,7 +55,7 @@ public final class TypeTest {
                         "Int"
                     )
                 )
-            ).java().getValue(),
+            ).java().code(),
             Matchers.stringContainsInOrder(
                 Lists.newArrayList(
                     "public interface Car", "{",

--- a/eo-compiler/src/test/resources/org/eolang/compiler/zero.eo
+++ b/eo-compiler/src/test/resources/org/eolang/compiler/zero.eo
@@ -1,0 +1,4 @@
+object zero as Money, Int:
+    Int @amount
+    Text @currency
+    ctor(Int amount, Text currency)


### PR DESCRIPTION
Replaced `Tree` `types` with more abstract `nodes`.
Implemented EO object parser in Program.g4.
Added `JavaClass` and `JavaInterface` to generate java code for EO types and objects.