### PR TITLE
Renaming Argument to Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ What exactly happens here? TBD
 ## Details
 
 There are types, objects, constructors, destructors, methods,
-attributes, arguments, exceptions, decorators.
+attributes, parameters, exceptions, decorators.
 
 There are _no_ classes, variables, operators, statements, annotations, reflection,
 type casting, generics, NULL, static methods, functions, lambdas.
@@ -114,7 +114,7 @@ A type is a _contract_ an object must obey.
 A type is very similar to interfaces from Java 1.0. A type has
 a name and a list of method
 declarations. Each method declaration has a name of the type of
-the return value, a method name, and a list of arguments. Each method
+the return value, a method name, and a list of parameters. Each method
 declaration has to take exactly one line, without any terminating
 symbol at the end, for example:
 
@@ -167,7 +167,7 @@ object alphabet as Book:
 ```
 
 An object can be made as a copy of an existing object, but with a
-different (or similar) set of arguments for one of the constructors, for
+different (or similar) set of parameters for one of the constructors, for
 example (`ot` is the name of the object):
 
 ```
@@ -290,9 +290,9 @@ in one of its types.
 
 All methods are public; there is no such thing as private or protected methods.
 
-A method may have zero to four arguments.
+A method may have zero to four parameters.
 
-Each argument must have an optional type and a name. If type is not provided
+Each parameter must have an optional type and a name. If type is not provided
 it has to be replaced with `?` mark, for example:
 
 ```

--- a/eo-compiler/src/main/antlr4/org/eolang/compiler/Program.g4
+++ b/eo-compiler/src/main/antlr4/org/eolang/compiler/Program.g4
@@ -1,7 +1,7 @@
 grammar Program;
 
 @header {
-    import org.eolang.compiler.syntax.Argument;
+    import org.eolang.compiler.syntax.Parameter;
     import org.eolang.compiler.syntax.Method;
     import org.eolang.compiler.syntax.Tree;
     import org.eolang.compiler.syntax.Type;
@@ -154,33 +154,33 @@ method_declaration returns [Method ret]
     HINAME
     SPACE
     LONAME
-    arguments_declaration
-    { $ret = new Method($LONAME.text, $arguments_declaration.ret, $HINAME.text); }
+    parameters_declaration
+    { $ret = new Method($LONAME.text, $parameters_declaration.ret, $HINAME.text); }
     ;
 
-arguments_declaration returns [List<Argument> ret]
+parameters_declaration returns [List<Parameter> ret]
     :
-    { $ret = new LinkedList<Argument>(); }
+    { $ret = new LinkedList<Parameter>(); }
     LBRACKET
     (
-        head=argument_declaration
+        head=parameter_declaration
         { $ret.add($head.ret); }
         (
             COMMA
             SPACE
-            tail=argument_declaration
+            tail=parameter_declaration
             { $ret.add($tail.ret); }
         )*
     )?
     RBRACKET
     ;
 
-argument_declaration returns [Argument ret]
+parameter_declaration returns [Parameter ret]
     :
     HINAME
     SPACE
     LONAME
-    { $ret = new Argument($LONAME.text, $HINAME.text); }
+    { $ret = new Parameter($LONAME.text, $HINAME.text); }
     ;
 
 object_instantiation
@@ -225,7 +225,7 @@ attribute_declaration
 ctor_declaration
     :
     CTOR
-    arguments_declaration
+    parameters_declaration
     COLON
     NEWLINE
     INDENT
@@ -259,17 +259,17 @@ object_copying
         COLON
         NEWLINE
         INDENT
-        object_argument
+        object_parameter
         (
             NEWLINE
             INDENT
-            object_argument
+            object_parameter
             DEDENT
         )*
     )?
     ;
 
-object_argument
+object_parameter
     :
     NUMBER
     |

--- a/eo-compiler/src/main/java/org/eolang/compiler/syntax/Method.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/syntax/Method.java
@@ -47,20 +47,20 @@ public final class Method {
     private final String type;
 
     /**
-     * Arguments.
+     * Parameters.
      */
-    private final Collection<Argument> arguments;
+    private final Collection<Parameter> parameters;
 
     /**
      * Ctor.
      * @param mtd Method name
-     * @param args Arguments
+     * @param params Parameters
      * @param rtp Return type
      */
-    public Method(final String mtd, final Collection<Argument> args,
+    public Method(final String mtd, final Collection<Parameter> params,
         final String rtp) {
         this.name = mtd;
-        this.arguments = args;
+        this.parameters = params;
         this.type = rtp;
     }
 
@@ -74,8 +74,8 @@ public final class Method {
             this.type,
             this.name,
             Joiner.on(", ").join(
-                this.arguments.stream().map(
-                    Argument::java
+                this.parameters.stream().map(
+                    Parameter::java
                 ).collect(Collectors.toList())
             )
         );

--- a/eo-compiler/src/main/java/org/eolang/compiler/syntax/Parameter.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/syntax/Parameter.java
@@ -24,30 +24,30 @@
 package org.eolang.compiler.syntax;
 
 /**
- * Argument.
+ * Parameter.
  *
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class Argument {
+public final class Parameter {
 
     /**
-     * Argument name.
+     * Parameter name.
      */
     private final String name;
 
     /**
-     * Argument type name.
+     * Parameter type name.
      */
     private final String type;
 
     /**
      * Ctor.
-     * @param arg Argument name
+     * @param arg Parameter name
      * @param tpn Type name
      */
-    public Argument(final String arg, final String tpn) {
+    public Parameter(final String arg, final String tpn) {
         this.name = arg;
         this.type = tpn;
     }

--- a/eo-compiler/src/test/java/org/eolang/compiler/syntax/MethodTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/syntax/MethodTest.java
@@ -46,8 +46,8 @@ public final class MethodTest {
             new Method(
                 "send",
                 Lists.newArrayList(
-                    new Argument("receiver", "Person"),
-                    new Argument("content", "Content")
+                    new Parameter("receiver", "Person"),
+                    new Parameter("content", "Content")
                 ),
                 "Message"
             ).java(),

--- a/eo-compiler/src/test/java/org/eolang/compiler/syntax/ParameterTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/syntax/ParameterTest.java
@@ -28,21 +28,21 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Test class for {@link Argument}.
+ * Test class for {@link Parameter}.
  * @author John Page (johnpagedev@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class ArgumentTest {
+public final class ParameterTest {
 
     /**
-     * A test that checks that Argument generates Java code.
+     * A test that checks that Parameter generates Java code.
      * @throws Exception if, well, an exception occurs.
      */
     @Test
     public void generatesJavaCode() throws Exception {
         MatcherAssert.assertThat(
-            new Argument(
+            new Parameter(
                 "dollars",
                 "Cash"
             ).java(),

--- a/eo-compiler/src/test/java/org/eolang/compiler/syntax/TypeTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/syntax/TypeTest.java
@@ -49,8 +49,8 @@ public final class TypeTest {
                     new Method(
                         "drive",
                         Lists.newArrayList(
-                            new Argument("x", "Integer"),
-                            new Argument("y", "Long")
+                            new Parameter("x", "Integer"),
+                            new Parameter("y", "Long")
                         ),
                         "Int"
                     )


### PR DESCRIPTION
Renaming class Argument (and all related stuff) to Parameter.
Strictly speaking this is a better name and it might be essential later on to draw a distinction between parameters (of a method) and the arguments (passed into a method).