### PR TITLE
Generate primary constructor for attributes

### DIFF
--- a/eo-compiler/src/main/java/org/eolang/compiler/java/JavaClass.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/java/JavaClass.java
@@ -28,7 +28,9 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
+import org.eolang.compiler.syntax.AttrFieldFormat;
 import org.eolang.compiler.syntax.Attribute;
+import org.eolang.compiler.syntax.AttributeFormat;
 
 /**
  * File with java class.
@@ -47,6 +49,11 @@ import org.eolang.compiler.syntax.Attribute;
  *  All methods should be public.
  */
 public final class JavaClass implements JavaFile {
+
+    /**
+     * Attribute field format.
+     */
+    private static final AttributeFormat FIELD_FORMAT = new AttrFieldFormat();
 
     /**
      * Class name.
@@ -111,7 +118,7 @@ public final class JavaClass implements JavaFile {
                 "\n",
                 this.fields
                     .stream()
-                    .map(Attribute::asField)
+                    .map(attr -> attr.java(JavaClass.FIELD_FORMAT))
                     .collect(Collectors.toList())
             ),
             this.pctor.code()

--- a/eo-compiler/src/main/java/org/eolang/compiler/java/JavaClass.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/java/JavaClass.java
@@ -64,6 +64,11 @@ public final class JavaClass implements JavaFile {
     private final Collection<Attribute> fields;
 
     /**
+     * Class primary constructor.
+     */
+    private final PrimaryConstructor pctor;
+
+    /**
      * Ctor.
      *
      * @param name Class name
@@ -78,16 +83,17 @@ public final class JavaClass implements JavaFile {
      *
      * @param name Class name
      * @param ifaces Implemented interfaces name
-     * @param fields Class fields
+     * @param attributes Object attributes
      */
     public JavaClass(
         final String name,
         final Collection<String> ifaces,
-        final Collection<Attribute> fields
+        final Collection<Attribute> attributes
     ) {
         this.name = name;
         this.ifaces = ifaces;
-        this.fields = fields;
+        this.fields = attributes;
+        this.pctor = new PrimaryConstructor(name, attributes);
     }
 
     @Override
@@ -98,16 +104,17 @@ public final class JavaClass implements JavaFile {
     @Override
     public String code() {
         return String.format(
-            "public final class %s implements %s {\n %s\n}",
+            "public final class %s implements %s {\n %s\n\n%s\n}",
             this.name,
             String.join(", ", this.ifaces),
             String.join(
                 "\n",
                 this.fields
                     .stream()
-                    .map(Attribute::java)
+                    .map(Attribute::asField)
                     .collect(Collectors.toList())
-            )
+            ),
+            this.pctor.code()
         );
     }
 }

--- a/eo-compiler/src/main/java/org/eolang/compiler/java/PrimaryConstructor.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/java/PrimaryConstructor.java
@@ -25,7 +25,10 @@ package org.eolang.compiler.java;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
+import org.eolang.compiler.syntax.AttrCtorInitFormat;
+import org.eolang.compiler.syntax.AttrCtorParamFormat;
 import org.eolang.compiler.syntax.Attribute;
+import org.eolang.compiler.syntax.AttributeFormat;
 
 /**
  * Java class primary constructor.
@@ -35,6 +38,18 @@ import org.eolang.compiler.syntax.Attribute;
  * @since 0.1
  */
 public final class PrimaryConstructor {
+
+    /**
+     * Attribute constructor parameter format.
+     */
+    private static final AttributeFormat CTOR_PARAM_FORMAT =
+        new AttrCtorParamFormat();
+
+    /**
+     * Attribute constructor initializer format.
+     */
+    private static final AttributeFormat CTOR_INIT_FORMAT =
+        new AttrCtorInitFormat();
 
     /**
      * Java class name.
@@ -73,14 +88,22 @@ public final class PrimaryConstructor {
                 ", ",
                 this.attributes
                     .stream()
-                    .map(Attribute::asCtorParam)
+                    .map(
+                        attr -> attr.java(
+                            PrimaryConstructor.CTOR_PARAM_FORMAT
+                        )
+                    )
                     .collect(Collectors.toList())
             ),
             String.join(
                 "\n",
                 this.attributes
                     .stream()
-                    .map(Attribute::asCtorInitializer)
+                    .map(
+                        attr -> attr.java(
+                            PrimaryConstructor.CTOR_INIT_FORMAT
+                        )
+                    )
                     .collect(Collectors.toList())
             )
         );

--- a/eo-compiler/src/main/java/org/eolang/compiler/java/PrimaryConstructor.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/java/PrimaryConstructor.java
@@ -21,74 +21,68 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.compiler.syntax;
+package org.eolang.compiler.java;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.eolang.compiler.syntax.Attribute;
 
 /**
- * Object attribute.
+ * Java class primary constructor.
  *
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class Attribute {
+public final class PrimaryConstructor {
 
     /**
-     * Attribute type name.
-     */
-    private final String type;
-
-    /**
-     * Attribute name.
+     * Java class name.
      */
     private final String name;
 
     /**
+     * Object attributes.
+     */
+    private final Collection<Attribute> attributes;
+
+    /**
      * Ctor.
      *
-     * @param type Attribute type
-     * @param name Attribute name
+     * @param name Class name.
+     * @param attributes Object attributes.
      */
-    public Attribute(final String type, final String name) {
-        this.type = type;
+    public PrimaryConstructor(
+        final String name,
+        final Collection<Attribute> attributes
+    ) {
+        this.attributes = attributes;
         this.name = name;
     }
 
     /**
-     * Generate java field code for object attribute.
+     * Generate constructor java code.
      *
-     * @return Generated java field code.
+     * @return Java code for constructor.
      */
-    public String asField() {
+    public String code() {
         return String.format(
-            "private final %s %s;",
-            this.type,
-            this.name
-        );
-    }
-
-    /**
-     * Generate java code for class constructor parameter.
-     *
-     * @return Generated constructor parameter.
-     */
-    public String asCtorParam() {
-        return String.format(
-            "final %s %s",
-            this.type,
-            this.name
-        );
-    }
-
-    /**
-     * Generate java code for primary constructor initializer.
-     *
-     * @return Generated constructor initializer.
-     */
-    public String asCtorInitializer() {
-        return String.format(
-            "this.%s = %s;",
+            "public %s(%s) {\n %s \n}",
             this.name,
-            this.name
+            String.join(
+                ", ",
+                this.attributes
+                    .stream()
+                    .map(Attribute::asCtorParam)
+                    .collect(Collectors.toList())
+            ),
+            String.join(
+                "\n",
+                this.attributes
+                    .stream()
+                    .map(Attribute::asCtorInitializer)
+                    .collect(Collectors.toList())
+            )
         );
     }
 }

--- a/eo-compiler/src/main/java/org/eolang/compiler/syntax/AttrCtorInitFormat.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/syntax/AttrCtorInitFormat.java
@@ -23,34 +23,17 @@
  */
 package org.eolang.compiler.syntax;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.Test;
-
 /**
- * Test for object's attribute.
+ * Attribute as java constructor initializer.
  *
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class AttributeTest {
+public final class AttrCtorInitFormat implements AttributeFormat {
 
-    /**
-     * Generates java code with provided format.
-     */
-    @Test
-    public void javaCode() {
-        MatcherAssert.assertThat(
-            new Attribute(
-                "Type",
-                "name"
-            ).java(
-                (type, name) -> String.format("%s:%s", type, name)
-            ),
-            Matchers.equalTo(
-                "Type:name"
-            )
-        );
+    @Override
+    public String code(final String type, final String name) {
+        return String.format("this.%s = %s;", name, name);
     }
 }

--- a/eo-compiler/src/main/java/org/eolang/compiler/syntax/AttrCtorParamFormat.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/syntax/AttrCtorParamFormat.java
@@ -23,34 +23,17 @@
  */
 package org.eolang.compiler.syntax;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.Test;
-
 /**
- * Test for object's attribute.
+ * Attribute as java constructor parameter.
  *
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class AttributeTest {
+public final class AttrCtorParamFormat implements AttributeFormat {
 
-    /**
-     * Generates java code with provided format.
-     */
-    @Test
-    public void javaCode() {
-        MatcherAssert.assertThat(
-            new Attribute(
-                "Type",
-                "name"
-            ).java(
-                (type, name) -> String.format("%s:%s", type, name)
-            ),
-            Matchers.equalTo(
-                "Type:name"
-            )
-        );
+    @Override
+    public String code(final String type, final String name) {
+        return String.format("final %s %s", type, name);
     }
 }

--- a/eo-compiler/src/main/java/org/eolang/compiler/syntax/AttrFieldFormat.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/syntax/AttrFieldFormat.java
@@ -23,34 +23,17 @@
  */
 package org.eolang.compiler.syntax;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.Test;
-
 /**
- * Test for object's attribute.
+ * Attribute as java class field.
  *
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class AttributeTest {
+public final class AttrFieldFormat implements AttributeFormat {
 
-    /**
-     * Generates java code with provided format.
-     */
-    @Test
-    public void javaCode() {
-        MatcherAssert.assertThat(
-            new Attribute(
-                "Type",
-                "name"
-            ).java(
-                (type, name) -> String.format("%s:%s", type, name)
-            ),
-            Matchers.equalTo(
-                "Type:name"
-            )
-        );
+    @Override
+    public String code(final String type, final String name) {
+        return String.format("private final %s %s;", type, name);
     }
 }

--- a/eo-compiler/src/main/java/org/eolang/compiler/syntax/Attribute.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/syntax/Attribute.java
@@ -54,41 +54,12 @@ public final class Attribute {
     }
 
     /**
-     * Generate java field code for object attribute.
+     * Generate java code with provided format.
      *
-     * @return Generated java field code.
+     * @param format Java code format
+     * @return Generated code
      */
-    public String asField() {
-        return String.format(
-            "private final %s %s;",
-            this.type,
-            this.name
-        );
-    }
-
-    /**
-     * Generate java code for class constructor parameter.
-     *
-     * @return Generated constructor parameter.
-     */
-    public String asCtorParam() {
-        return String.format(
-            "final %s %s",
-            this.type,
-            this.name
-        );
-    }
-
-    /**
-     * Generate java code for primary constructor initializer.
-     *
-     * @return Generated constructor initializer.
-     */
-    public String asCtorInitializer() {
-        return String.format(
-            "this.%s = %s;",
-            this.name,
-            this.name
-        );
+    public String java(final AttributeFormat format) {
+        return format.code(this.type, this.name);
     }
 }

--- a/eo-compiler/src/main/java/org/eolang/compiler/syntax/AttributeFormat.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/syntax/AttributeFormat.java
@@ -23,34 +23,21 @@
  */
 package org.eolang.compiler.syntax;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.Test;
-
 /**
- * Test for object's attribute.
+ * Object attribute java code format.
  *
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class AttributeTest {
+public interface AttributeFormat {
 
     /**
-     * Generates java code with provided format.
+     * Java code for attribute.
+     *
+     * @param type Attribute type
+     * @param name Attribute name
+     * @return Java code string.
      */
-    @Test
-    public void javaCode() {
-        MatcherAssert.assertThat(
-            new Attribute(
-                "Type",
-                "name"
-            ).java(
-                (type, name) -> String.format("%s:%s", type, name)
-            ),
-            Matchers.equalTo(
-                "Type:name"
-            )
-        );
-    }
+    String code(final String type, final String name);
 }

--- a/eo-compiler/src/test/java/org/eolang/compiler/ProgramTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/ProgramTest.java
@@ -109,6 +109,11 @@ public final class ProgramTest {
                     "implements",
                     "Int",
                     "{",
+                    "private final Int n;",
+                    "public fibonacci(final Int n)",
+                    "{",
+                    "this.n = n",
+                    "}",
                     "}"
                 )
             )

--- a/eo-compiler/src/test/java/org/eolang/compiler/java/JavaClassTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/java/JavaClassTest.java
@@ -116,6 +116,10 @@ public final class JavaClassTest {
                     "implements Error",
                     "{",
                     "private final Text msg;",
+                    String.format("public %s(final Text msg)", name),
+                    "{",
+                    "this.msg = msg;",
+                    "}",
                     "}"
                 )
             )

--- a/eo-compiler/src/test/java/org/eolang/compiler/java/PrimaryConstructorTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/java/PrimaryConstructorTest.java
@@ -21,60 +21,49 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.compiler.syntax;
+package org.eolang.compiler.java;
 
+import java.util.Arrays;
+import org.eolang.compiler.syntax.Attribute;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Test for object's attribute.
+ * Java class primary constructor test.
  *
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class AttributeTest {
+public final class PrimaryConstructorTest {
 
     /**
-     * Attribute generates proper field java code.
+     * Generates constructor code with fields initialization.
      */
     @Test
-    public void generatedJavaField() {
+    public void generatesJavaCode() {
         MatcherAssert.assertThat(
-            new Attribute(
-                "Text",
-                "name"
-            ).asField(),
-            Matchers.is("private final Text name;")
-        );
-    }
-
-    /**
-     * Attribute generates constructor parameter java code.
-     */
-    @Test
-    public void generatedJavaCtorParam() {
-        MatcherAssert.assertThat(
-            new Attribute(
-                "Int",
-                "number"
-            ).asCtorParam(),
-            Matchers.is("final Int number")
-        );
-    }
-
-    /**
-     * Attribute generates constructor initializer java code.
-     */
-    @Test
-    public void generatesJavaCtorInitializer() {
-        MatcherAssert.assertThat(
-            new Attribute(
-                "Attribute",
-                "attr"
-            ).asCtorInitializer(),
-            Matchers.is("this.attr = attr;")
+            new PrimaryConstructor(
+                "color",
+                Arrays.asList(
+                    new Attribute("Byte", "alpha"),
+                    new Attribute("Int", "rgb")
+                )
+            ).code(),
+            Matchers.stringContainsInOrder(
+                Arrays.asList(
+                    "public",
+                    "color(",
+                    "final Byte alpha",
+                    "final Int rgb",
+                    ")",
+                    "{",
+                    "this.alpha = alpha;",
+                    "this.rgb = rgb;",
+                    "}"
+                )
+            )
         );
     }
 }

--- a/eo-compiler/src/test/java/org/eolang/compiler/syntax/AttrCtorInitFormatTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/syntax/AttrCtorInitFormatTest.java
@@ -28,29 +28,25 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Test for object's attribute.
+ * Test for constructor initializer attribute format.
  *
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class AttributeTest {
+public final class AttrCtorInitFormatTest {
 
     /**
-     * Generates java code with provided format.
+     * Generates constructor initializer java code.
      */
     @Test
     public void javaCode() {
         MatcherAssert.assertThat(
-            new Attribute(
-                "Type",
-                "name"
-            ).java(
-                (type, name) -> String.format("%s:%s", type, name)
+            new AttrCtorInitFormat().code(
+                "Attribute",
+                "attr"
             ),
-            Matchers.equalTo(
-                "Type:name"
-            )
+            Matchers.is("this.attr = attr;")
         );
     }
 }

--- a/eo-compiler/src/test/java/org/eolang/compiler/syntax/AttrCtorParamFormatTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/syntax/AttrCtorParamFormatTest.java
@@ -28,29 +28,25 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Test for object's attribute.
+ * Test for constructor parameter attribute format.
  *
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class AttributeTest {
+public final class AttrCtorParamFormatTest {
 
     /**
-     * Generates java code with provided format.
+     * Generates constructor parameter java code.
      */
     @Test
     public void javaCode() {
         MatcherAssert.assertThat(
-            new Attribute(
-                "Type",
-                "name"
-            ).java(
-                (type, name) -> String.format("%s:%s", type, name)
+            new AttrCtorParamFormat().code(
+                "Int",
+                "number"
             ),
-            Matchers.equalTo(
-                "Type:name"
-            )
+            Matchers.is("final Int number")
         );
     }
 }

--- a/eo-compiler/src/test/java/org/eolang/compiler/syntax/AttrFieldFormatTest.java
+++ b/eo-compiler/src/test/java/org/eolang/compiler/syntax/AttrFieldFormatTest.java
@@ -28,29 +28,25 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Test for object's attribute.
+ * Test for field attribute format.
  *
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.1
  */
-public final class AttributeTest {
+public final class AttrFieldFormatTest {
 
     /**
-     * Generates java code with provided format.
+     * Generates field java code.
      */
     @Test
     public void javaCode() {
         MatcherAssert.assertThat(
-            new Attribute(
-                "Type",
+            new AttrFieldFormat().code(
+                "Text",
                 "name"
-            ).java(
-                (type, name) -> String.format("%s:%s", type, name)
             ),
-            Matchers.equalTo(
-                "Type:name"
-            )
+            Matchers.is("private final Text name;")
         );
     }
 }


### PR DESCRIPTION
Generate java code for class primary constructor with parameters and field initializers.
Constructor parameters generated in same order as attributes in object (described in #61).
Primary constructors are necesary to implement secondaries #104.